### PR TITLE
[quick fix] don't use twig version higher then 1.16.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "symfony/console": "~2.1",
         "symfony/finder": "~2.1",
-        "twig/twig": "~1.12"
+        "twig/twig": "~1.12,<1.16.2"
     },
     "autoload": {
         "psr-0": { "Asm89\\Twig\\Lint\\": "src/" }


### PR DESCRIPTION
Liniter is no longer compatible with twig 1.16.2 

Since arguments changed for protected method `getTestNodeClass` of `Twig_Extension_Core`
https://github.com/asm89/twig-lint/blob/master/src/Asm89/Twig/Lint/Extension/StubbedCore.php#L30
https://github.com/twigphp/Twig/blob/v1.16.2/lib/Twig/Extension/Core.php#L341

Also some tests starts to faling for twig 1.16.2

