### PR TITLE
twig >1.16.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 box.phar
 composer.phar
+composer.lock
 twig-lint.phar
 vendor

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "symfony/console": "~2.1",
         "symfony/finder": "~2.1",
-        "twig/twig": "~1.12"
+        "twig/twig": ">=1.16.2,<2.0"
     },
     "autoload": {
         "psr-0": { "Asm89\\Twig\\Lint\\": "src/" }

--- a/src/Asm89/Twig/Lint/Extension/StubbedCore.php
+++ b/src/Asm89/Twig/Lint/Extension/StubbedCore.php
@@ -27,7 +27,7 @@ class StubbedCore extends \Twig_Extension_Core
      *
      * @return string
      */
-    protected function getTestNodeClass(\Twig_Parser $parser, $name, $line)
+    protected function getTestNodeClass(\Twig_Parser $parser, $name)
     {
         return 'Twig_Node_Expression_Test';
     }

--- a/src/Asm89/Twig/Lint/Extension/StubbedCore.php
+++ b/src/Asm89/Twig/Lint/Extension/StubbedCore.php
@@ -31,4 +31,13 @@ class StubbedCore extends \Twig_Extension_Core
     {
         return 'Twig_Node_Expression_Test';
     }
+
+    protected function getTestName(\Twig_Parser $parser, $line)
+    {
+        try {
+            return parent::getTestName($parser, $line);
+        } catch (\Twig_Error_Syntax $exception) {
+            return 'null';
+        }
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+error_reporting(E_ALL | E_STRICT);
+
 if (file_exists($file = __DIR__.'/../vendor/autoload.php')) {
     $autoload = require_once $file;
 } else {


### PR DESCRIPTION
As I suggested in #9 it would be possible to have two versions of twig-lint to work around the API changes currently breaking with twig >1.16.2

This version is tested with 1.17, if this solution would be a possibility for you, @asm89, I would test all versions in between.

Ideas, suggestions?