### PR TITLE
Makes 3rd arg Extension::getTestNodeClass optional

### DIFF
--- a/src/Asm89/Twig/Lint/Extension/StubbedCore.php
+++ b/src/Asm89/Twig/Lint/Extension/StubbedCore.php
@@ -27,7 +27,7 @@ class StubbedCore extends \Twig_Extension_Core
      *
      * @return string
      */
-    protected function getTestNodeClass(\Twig_Parser $parser, $name, $line)
+    protected function getTestNodeClass(\Twig_Parser $parser, $name, $line = null)
     {
         return 'Twig_Node_Expression_Test';
     }


### PR DESCRIPTION
With warnings enabled, the the linter often throws a warning due to a missing third argument:

    PHP Warning:  Missing argument 3 for Asm89\Twig\Lint\Extension\StubbedCore::getTestNodeClass(), called in /path/to/project/vendor/twig/twig/lib/Twig/Extension/Core.php on line 302 and defined in /path/to/project/vendor/asm89/twig-lint/src/Asm89/Twig/Lint/Extension/StubbedCore.php on line 30

Examining the parent class in twig 1.18, this arg is not even present in the signature. Rather than remove it entirely, I defaulted it to null. It's possible it needs to be dropped altogether for eliminating the strict warning about mismatched method signatures.