### PR TITLE
Prevent validation fail on custom twig tests

### DIFF
--- a/src/Asm89/Twig/Lint/StubbedEnvironment.php
+++ b/src/Asm89/Twig/Lint/StubbedEnvironment.php
@@ -24,6 +24,7 @@ class StubbedEnvironment extends \Twig_Environment
 {
     private $stubFilters;
     private $stubFunctions;
+    private $stubTests;
     protected $parsers;
 
     /**
@@ -62,5 +63,17 @@ class StubbedEnvironment extends \Twig_Environment
         }
 
         return $this->stubFunctions[$name];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTest($name)
+    {
+        if (!isset($this->stubTests[$name])) {
+            $this->stubTests[$name] = new \Twig_SimpleTest('stub', function(){});
+        }
+
+        return $this->stubTests[$name];
     }
 }


### PR DESCRIPTION
This stub method prevents fails when not recognizing twig tests.

For example, Symfony FormExtension selectedchoice is not recognized by twig lint:

     {% set options = choices %}
     {% for group_label, choice in options %}
        <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.data.name}}</option>
     {% endfor %}

throws: 

>> The test "selectedchoice" does not exist 

    
