### PR TITLE
Update version to correct release.

### DIFF
--- a/bin/twig-lint
+++ b/bin/twig-lint
@@ -14,5 +14,5 @@ require __DIR__.'/../src/bootstrap.php';
 
 use Asm89\Twig\Lint\Console\Application;
 
-$application = new Application('Twig lint', 'v1.0.1');
+$application = new Application('Twig lint', 'v1.0.2');
 $application->run();


### PR DESCRIPTION
I got a little confused when running `$ twig-lint -v` which was reporting v1.0.1 when my composer told me I had v1.0.2.